### PR TITLE
add delay for close button event (for leaving lab) (untested)

### DIFF
--- a/arduino/src/sphincter.ino
+++ b/arduino/src/sphincter.ino
@@ -255,6 +255,7 @@ void processButtonEvents() {
     else if( !digitalRead(BUTTON_CLOSE) && close_was_pressed ) {
 
         close_was_pressed = false;
+        delay(1000*20) //20-second delay for leaving lab
         turnLock(LOCK_CLOSE);
 
     }


### PR DESCRIPTION
Fügt eine kleine Verzögerung beim Schließen hinzu, damit das Lab verlassen werden kann.
DIe Verzögerung ist großzügig (20 sec)
Vorsicht: der Code ist ungetestet
